### PR TITLE
NewSession page, with stubbed actions

### DIFF
--- a/app/appRoutes.js
+++ b/app/appRoutes.js
@@ -6,6 +6,7 @@ import { UserAuthWrapper } from 'redux-auth-wrapper';
 import App from './containers/App.jsx';
 import Dashboard from './containers/Dashboard.jsx';
 import Session from './containers/Session.jsx';
+import NewSession from './containers/NewSession.jsx';
 import Calendar from './containers/Calendar.jsx';
 import EventSessions from './containers/EventSessions.jsx';
 import AuthService from './services/AuthService.js';
@@ -21,6 +22,7 @@ const UserIsAuthenticated = UserAuthWrapper({
 const appRoutes = (
   <Route component={UserIsAuthenticated(App)}>
       <Route path="/dashboard" component={Dashboard} />
+      <Route path="/sessions/new" component={NewSession} />
       <Route path="/sessions/:sessionId" component={Session} />
       <Route path="/calendar" component={Calendar}>
         <Route path=":eventId" component={EventSessions} />

--- a/app/components/Session/NewSessionForm.jsx
+++ b/app/components/Session/NewSessionForm.jsx
@@ -1,0 +1,194 @@
+import React, { Component, PropTypes } from 'react';
+
+
+// A form into which the user can enter details of a new session
+class NewSessionForm extends Component {
+
+    sendValue(handler) {
+        return (ev) => {
+            handler(ev.target.value);
+        };
+    }
+
+    adminsDroplist() {
+        if (this.props.isFetchingAdmins) {
+            return <select><option>Loading admins...</option></select>;
+        }
+
+        return (
+            <select
+              id="admin"
+              name="admin"
+              value={this.props.adminId}
+              onChange={this.sendValue(this.props.adminSelected)}
+            >
+              <option value=""></option>
+              {
+                  this.props.admins.map(s =>
+                    <option key={`adm-${s.id}`} value={s.id}>{`${s.forename} ${s.surname}`}</option>
+                  )
+              }
+            </select>
+        );
+    }
+
+    speakersDroplist() {
+        if (this.props.isFetchingSpeakers) {
+            return <select><option>Loading speakers...</option></select>;
+        }
+
+        return (
+            <select
+              id="speaker"
+              name="speaker"
+              value={this.props.speakerId}
+              onChange={this.sendValue(this.props.speakerSelected)}
+            >
+              <option value=""></option>
+              {
+                  this.props.speakers.map(s =>
+                    <option key={`spk-${s.id}`} value={s.id}>{`${s.forename} ${s.surname}`}</option>
+                  )
+              }
+            </select>
+        );
+    }
+
+    submitButton() {
+        const buttonAttributes = {};
+
+        const validationMsg =
+            this.props.titleValidation ||
+            this.props.descriptionValidation ||
+            this.props.dateValidation ||
+            this.props.adminIdValidation ||
+            this.props.speakerIdValidation;
+
+        if (validationMsg) {
+            buttonAttributes.disabled = 'disabled';
+        }
+
+        return (
+            <input type="submit" value="Submit" {...buttonAttributes} />
+        );
+    }
+
+    render() {
+        return (
+            <div>
+              <h1>Create New Session</h1>
+              <form
+                onSubmit={(event) => { event.preventDefault(); this.props.submit(); return false; } }
+              >
+                  <fieldset>
+                  <legend>New session details</legend>
+                    <table>
+                      <tbody>
+                        <tr>
+                          <td><label htmlFor="title">Title <span className="error">*</span></label></td>
+                          <td>
+                            <input
+                              type="text"
+                              id="title"
+                              name="title"
+                              size="40"
+                              value={this.props.title}
+                              onChange={this.sendValue(this.props.titleEntered)}
+                            />
+                          </td>
+                          <td>{this.props.titleValidation}</td>
+                        </tr>
+                        <tr>
+                          <td><label htmlFor="description">Description <span className="error">*</span></label></td>
+                          <td>
+                            <input
+                              type="text"
+                              id="description"
+                              name="description"
+                              size="40"
+                              value={this.props.description}
+                              onChange={this.sendValue(this.props.descriptionEntered)}
+                            />
+                          </td>
+                          <td>{this.props.descriptionValidation}</td>
+                        </tr>
+                        <tr>
+                          <td><label htmlFor="date">Session date <span className="error">*</span></label></td>
+                          <td>
+                            <input
+                              type="text"
+                              id="date"
+                              name="dob"
+                              size="10"
+                              value={this.props.date}
+                              onChange={this.sendValue(this.props.dateEntered)}
+                            />
+                            <span className="note">DD/MM/YYYY</span>
+                          </td>
+                          <td>{this.props.dateValidation}</td>
+                        </tr>
+                        <tr>
+                          <td><label htmlFor="speaker">Speaker <span className="error">*</span></label></td>
+                          <td>{this.speakersDroplist()}</td>
+                          <td>{this.props.speakerIdValidation}</td>
+                        </tr>
+                        <tr>
+                          <td><label htmlFor="admin">Admin <span className="error">*</span></label></td>
+                          <td>{this.adminsDroplist()}</td>
+                          <td>{this.props.adminIdValidation}</td>
+                        </tr>
+                        <tr>
+                        <td></td>
+                        <td>
+                          {this.submitButton()}
+                          {this.props.submitMessage}
+                        </td>
+                        </tr>
+                      </tbody>
+                    </table>
+                </fieldset>
+              </form>
+            </div>
+        );
+    }
+}
+
+
+NewSessionForm.propTypes = {
+    // Data captured by the form
+    title: PropTypes.string,
+    titleValidation: PropTypes.string,
+
+    description: PropTypes.string,
+    descriptionValidation: PropTypes.string,
+
+    date: PropTypes.string,
+    dateValidation: PropTypes.string,
+
+    speakerId: PropTypes.string,
+    speakerIdValidation: PropTypes.string,
+
+    adminId: PropTypes.string,
+    adminIdValidation: PropTypes.string,
+
+    error: PropTypes.string,
+
+    // Droplists async population
+    admins: PropTypes.array,
+    speakers: PropTypes.array,
+    isFetchingAdmins: PropTypes.bool,
+    isFetchingSpeakers: PropTypes.bool,
+
+    // Saving
+    submitMessage: PropTypes.string,
+
+    // Handlers for user actions
+    submit: PropTypes.func,
+    titleEntered: PropTypes.func,
+    descriptionEntered: PropTypes.func,
+    dateEntered: PropTypes.func,
+    speakerSelected: PropTypes.func,
+    adminSelected: PropTypes.func,
+};
+
+export default NewSessionForm;

--- a/app/containers/NewSession.jsx
+++ b/app/containers/NewSession.jsx
@@ -1,0 +1,119 @@
+import React, { Component, PropTypes } from 'react';
+import { connect } from 'react-redux';
+import NewSessionForm from '../components/Session/NewSessionForm.jsx';
+
+// React container component for creating a new session.
+// Acts as a container for the display-only NewSessionForm component.
+class NewSession extends Component {
+
+    constructor(props) {
+        super(props);
+        this.titleEntered = this.titleEntered.bind(this);
+        this.descriptionEntered = this.descriptionEntered.bind(this);
+        this.dateEntered = this.dateEntered.bind(this);
+        this.speakerSelected = this.speakerSelected.bind(this);
+        this.adminSelected = this.adminSelected.bind(this);
+        this.submit = this.submit.bind(this);
+    }
+
+    componentDidMount() {
+        alert('TODO: get all speakers & admins for droplist');
+    }
+
+
+    titleEntered(title) {
+        alert('TODO: dispatch action to set value in redux store');
+    }
+
+    descriptionEntered(description) {
+        alert('TODO: dispatch action to set value in redux store');
+    }
+
+    dateEntered(date) {
+        alert('TODO: dispatch action to set value in redux store');
+    }
+
+    speakerSelected(speakerId) {
+        alert('TODO: dispatch action to set value in redux store');
+    }
+
+    adminSelected(adminId) {
+        alert('TODO: dispatch action to set value in redux store');
+    }
+
+    submit() {
+        alert('TODO: dispatch action to make REST call to save session');
+    }
+
+    render() {
+        return (
+          <NewSessionForm
+            title={this.props.title}
+            titleValidation={this.props.titleValidation}
+            description={this.props.description}
+            descriptionValidation={this.props.descriptionValidation}
+            date={this.props.date}
+            dateValidation={this.props.dateValidation}
+            speakerId={this.props.speakerId}
+            speakerIdValidation={this.props.speakerIdValidation}
+            adminId={this.props.adminId}
+            adminIdValidation={this.props.adminIdValidation}
+            error={this.props.error}
+
+            // TODO: replace dummy data with actual retrieved data
+            admins={[{ forename: 'Joe', surname: 'Bloggs', id: '1111.2222' }]}
+            speakers={[{ forename: 'Blodwyn', surname: 'Jones', id: '3333.4444' }]}
+
+            isFetchingAdmins={this.props.isFetchingAdmins}
+            isFetchingSpeakers={this.props.isFetchingSpeakers}
+            submitMessage={this.props.submitMessage}
+
+            submit={this.submit}
+            titleEntered={this.titleEntered}
+            descriptionEntered={this.descriptionEntered}
+            dateEntered={this.dateEntered}
+            speakerSelected={this.speakerSelected}
+            adminSelected={this.adminSelected}
+          />
+        );
+    }
+}
+
+function mapStateToProps(state) {
+    return {
+        // TODO: map redux state to properties for sub-components
+    };
+}
+
+NewSession.contextTypes = {
+    router: PropTypes.func.isRequired,
+};
+
+
+NewSession.propTypes = {
+    title: PropTypes.string,
+    titleValidation: PropTypes.string,
+    description: PropTypes.string,
+    descriptionValidation: PropTypes.string,
+    date: PropTypes.string,
+    dateValidation: PropTypes.string,
+    speakerId: PropTypes.string,
+    speakerIdValidation: PropTypes.string,
+    adminId: PropTypes.string,
+    adminIdValidation: PropTypes.string,
+    error: PropTypes.string,
+    isFetchingAdmins: PropTypes.bool,
+    isFetchingSpeakers: PropTypes.bool,
+    submitMessage: PropTypes.string,
+    submit: PropTypes.func,
+    titleEntered: PropTypes.func,
+    descriptionEntered: PropTypes.func,
+    dateEntered: PropTypes.func,
+    speakerSelected: PropTypes.func,
+    adminSelected: PropTypes.func,
+    dispatch: PropTypes.func,
+    admins: PropTypes.array,
+    speakers: PropTypes.array,
+};
+
+export default connect(mapStateToProps)(NewSession);


### PR DESCRIPTION
So, we have:

* New route in appRoutes.js to map the route /sessions/new to the NewSession component
* A 'display only' component called NewSessionForm, that displays a form to enter a new session, including validation messages for each field, prompts, etc.
* A 'container' component called NewSession, that will do all the 'work' of updating the store when the user enters values, retrieving the admin/speaker data for droplists, etc. All stubbed for now.