### PR TITLE
Added reasoning behind ignoring config.dev.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ git clone https://github.com/BristechSRM/frontend.git
 cd frontend
 ```
 
-Add app/config/config.dev.json
+Create `app/config/config.dev.json` based on `app/config/template.config.dev.json`.  We don't commit `config.dev.json` to source control, which allows each developer to have a different local config without committing those changes.
 
 ```
 npm install


### PR DESCRIPTION
It wasn't clear to me why we are ignoring `config.dev.json` so having found out, I thought I'd help out any other new team members.